### PR TITLE
Jbardin migration

### DIFF
--- a/balancer.go
+++ b/balancer.go
@@ -10,7 +10,7 @@ import (
 // initial connections fails.
 
 // RR is always weighted.
-// we don't reduce the weight, we just distrubute exactly "Weight" calls in
+// we don't reduce the weight, we just distribute exactly "Weight" calls in
 // a row
 func (s *Service) roundRobin() []*Backend {
 	s.Lock()

--- a/client/client.go
+++ b/client/client.go
@@ -21,7 +21,7 @@ const (
 	DefaultTimeout = 2000
 
 	// Default interval in milliseconds between health checks
-	DefaultCheckInterval = 2000
+	DefaultCheckInterval = 5000
 
 	// Default network connections are TCP
 	DefaultNet = "tcp"

--- a/registry.go
+++ b/registry.go
@@ -148,6 +148,7 @@ func (s *ServiceRegistry) UpdateConfig(cfg client.Config) error {
 
 	// Set globals
 	//FIXME: we might need to unset something
+
 	if cfg.Balance != "" {
 		s.cfg.Balance = cfg.Balance
 	}
@@ -180,7 +181,6 @@ func (s *ServiceRegistry) UpdateConfig(cfg client.Config) error {
 	errors := &multiError{}
 
 	for _, svc := range cfg.Services {
-
 		for _, port := range invalidPorts {
 			if strings.HasSuffix(svc.Addr, port) {
 				// TODO: report conflicts between service listeners
@@ -247,7 +247,7 @@ func (s *ServiceRegistry) AddService(svcCfg client.ServiceConfig) error {
 		return ErrDuplicateService
 	}
 
-	setServiceDefaults(&svcCfg, s.cfg)
+	s.setServiceDefaults(&svcCfg)
 
 	service := NewService(svcCfg)
 	err := service.start()
@@ -547,27 +547,28 @@ func (s *ServiceRegistry) String() string {
 	return string(marshal(s.Config()))
 }
 
-// set any missing defaults on a Service
-func setServiceDefaults(svc *client.ServiceConfig, def client.Config) {
-	if svc.Balance == "" && def.Balance != "" {
-		svc.Balance = def.Balance
+// set any missing defaults on a ServiceConfig
+// ServiceRegistry *must* be locked
+func (s *ServiceRegistry) setServiceDefaults(svc *client.ServiceConfig) {
+	if svc.Balance == "" && s.cfg.Balance != "" {
+		svc.Balance = s.cfg.Balance
 	}
-	if svc.CheckInterval == 0 && def.CheckInterval != 0 {
-		svc.CheckInterval = def.CheckInterval
+	if svc.CheckInterval == 0 && s.cfg.CheckInterval != 0 {
+		svc.CheckInterval = s.cfg.CheckInterval
 	}
-	if svc.Fall == 0 && def.Fall != 0 {
-		svc.Fall = def.Fall
+	if svc.Fall == 0 && s.cfg.Fall != 0 {
+		svc.Fall = s.cfg.Fall
 	}
-	if svc.Rise == 0 && def.Rise != 0 {
-		svc.Rise = def.Rise
+	if svc.Rise == 0 && s.cfg.Rise != 0 {
+		svc.Rise = s.cfg.Rise
 	}
-	if svc.ClientTimeout == 0 && def.ClientTimeout != 0 {
-		svc.ClientTimeout = def.ClientTimeout
+	if svc.ClientTimeout == 0 && s.cfg.ClientTimeout != 0 {
+		svc.ClientTimeout = s.cfg.ClientTimeout
 	}
-	if svc.ServerTimeout == 0 && def.ServerTimeout != 0 {
-		svc.ServerTimeout = def.ServerTimeout
+	if svc.ServerTimeout == 0 && s.cfg.ServerTimeout != 0 {
+		svc.ServerTimeout = s.cfg.ServerTimeout
 	}
-	if svc.DialTimeout == 0 && def.DialTimeout != 0 {
-		svc.DialTimeout = def.DialTimeout
+	if svc.DialTimeout == 0 && s.cfg.DialTimeout != 0 {
+		svc.DialTimeout = s.cfg.DialTimeout
 	}
 }

--- a/registry.go
+++ b/registry.go
@@ -147,7 +147,7 @@ type ServiceRegistry struct {
 func (s *ServiceRegistry) UpdateConfig(cfg client.Config) error {
 
 	// Set globals
-	//FIXME: we might need to unset something
+	//TODO: we might need to unset something
 
 	if cfg.Balance != "" {
 		s.cfg.Balance = cfg.Balance

--- a/service.go
+++ b/service.go
@@ -155,7 +155,8 @@ func NewService(cfg client.ServiceConfig) *Service {
 	return s
 }
 
-// Update only fields that apply to all backends and connections
+// Update the defaults on the running service from a sample config. Only
+// fields that apply to all backends and connections will be updated.
 func (s *Service) UpdateDefaults(cfg client.ServiceConfig) error {
 	s.Lock()
 	defer s.Unlock()

--- a/service.go
+++ b/service.go
@@ -126,17 +126,17 @@ func NewService(cfg client.ServiceConfig) *Service {
 	s.httpProxy.OnResponse = []ProxyCallback{logProxyRequest, s.errStats, s.errorPages.CheckResponse}
 
 	if s.CheckInterval == 0 {
-		s.CheckInterval = 2000
+		s.CheckInterval = client.DefaultCheckInterval
 	}
 	if s.Rise == 0 {
-		s.Rise = 2
+		s.Rise = client.DefaultRise
 	}
 	if s.Fall == 0 {
-		s.Fall = 2
+		s.Fall = client.DefaultFall
 	}
 
 	if s.Network == "" {
-		s.Network = "tcp"
+		s.Network = client.DefaultNet
 	}
 
 	for _, b := range cfg.Backends {
@@ -144,12 +144,15 @@ func NewService(cfg client.ServiceConfig) *Service {
 	}
 
 	switch cfg.Balance {
-	case "RR", "":
+	case client.RoundRobin:
 		s.next = s.roundRobin
-	case "LC":
+	case client.LeastConn:
 		s.next = s.leastConn
 	default:
-		log.Printf("invalid balancing algorithm '%s'", cfg.Balance)
+		if cfg.Balance != "" {
+			log.Warnf("invalid balancing algorithm '%s'", cfg.Balance)
+		}
+		s.next = s.roundRobin
 	}
 
 	return s


### PR DESCRIPTION
- Add documentation on the client package
- client gets an http.Client with a timeout
- define consts for default values, and replace magic constants in code
- Fix how defaults are set, and how configurations are compared (still
  WIP, but this still passes all tests)
- remove magic consts from shuttle, and replace with defaults values from client package. 
