### PR TITLE
Configure https-redirect per service

### DIFF
--- a/client/config.go
+++ b/client/config.go
@@ -69,6 +69,11 @@ type Config struct {
 	// backend service, including name resolution.
 	DialTimeout int `json:"connect_timeout"`
 
+	// HTTPSRedirect when set to true, redirects non-https request to https on
+	// all services. The request may either have Scheme set to 'https',  or
+	// have an "X-Forwarded-Proto: https" header.
+	HTTPSRedirect bool `json:"https-redirect"`
+
 	// Services is a slice of ServiceConfig for each service. A service
 	// corresponds to one listening connection, and a number of backends to
 	// proxy.
@@ -188,6 +193,11 @@ type ServiceConfig struct {
 	// DialTimeout is the timeout in milliseconds for connections to the
 	// backend service, including name resolution.
 	DialTimeout int `json:"connect_timeout"`
+
+	// HTTPSRedirect when set to true, redirects non-https request to https. The
+	// request may either have Scheme set to 'https',  or have an
+	// "X-Forwarded-Proto: https" header.
+	HTTPSRedirect bool `json:"https-redirect"`
 
 	// Virtualhosts is a set of virtual hostnames for which this service should
 	// handle HTTP requests.

--- a/http.go
+++ b/http.go
@@ -29,9 +29,6 @@ type HostRouter struct {
 	// the http frontend
 	server *http.Server
 
-	// automatically redirect to https
-	SSLOnly bool
-
 	// HTTP/HTTPS
 	Scheme string
 
@@ -52,15 +49,6 @@ func (r *HostRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	reqId := genId()
 	req.Header.Set("X-Request-Id", reqId)
 	w.Header().Add("X-Request-Id", reqId)
-
-	if r.SSLOnly {
-		if req.TLS != nil || req.Header.Get("X-Forwarded-Proto") != "https" {
-			//TODO: verify RequestURI
-			redirLoc := "https://" + req.Host + req.RequestURI
-			http.Redirect(w, req, redirLoc, http.StatusMovedPermanently)
-			return
-		}
-	}
 
 	var err error
 	host := req.Host
@@ -137,7 +125,6 @@ func startHTTPServer(wg *sync.WaitGroup) {
 	}
 
 	httpRouter = NewHostRouter(httpServer)
-	httpRouter.SSLOnly = sslOnly
 
 	httpRouter.Start(nil)
 }
@@ -224,7 +211,6 @@ func startHTTPSServer(wg *sync.WaitGroup) {
 
 	httpRouter = NewHostRouter(httpsServer)
 	httpRouter.Scheme = "https"
-	httpRouter.SSLOnly = sslOnly
 
 	httpRouter.Start(nil)
 }

--- a/main.go
+++ b/main.go
@@ -26,8 +26,8 @@ var (
 	// Debug logging
 	debug bool
 
-	// Redirect to SSL endpoint
-	sslOnly bool
+	// Redirect to HTTPS endpoint
+	httpsRedirect bool
 
 	// version flags
 	version      bool
@@ -47,8 +47,8 @@ func init() {
 	flag.BoolVar(&debug, "debug", false, "verbose logging")
 	flag.BoolVar(&version, "v", false, "display version")
 
-	// FIXME: we may only want this for one HTTPRouter
-	flag.BoolVar(&sslOnly, "sslOnly", false, "require SSL")
+	flag.BoolVar(&httpsRedirect, "https-redirect", false, "redirect all http vhost requests to https")
+	flag.BoolVar(&httpsRedirect, "sslOnly", false, "require https (deprecated)")
 
 	flag.Parse()
 }

--- a/registry.go
+++ b/registry.go
@@ -172,6 +172,11 @@ func (s *ServiceRegistry) UpdateConfig(cfg client.Config) error {
 		s.cfg.DialTimeout = cfg.DialTimeout
 	}
 
+	// apply the https rediect flag
+	if httpsRedirect {
+		s.cfg.HTTPSRedirect = true
+	}
+
 	invalidPorts := []string{
 		// FIXME: lookup bound addresses some other way.  We may have multiple
 		//        http listeners, as well as all listening Services.
@@ -275,6 +280,7 @@ func (s *ServiceRegistry) AddService(svcCfg client.ServiceConfig) error {
 // Replacing a configuration will shutdown the existing service, and start a
 // new one, which will cause the listening socket to be temporarily
 // unavailable.
+// FIXME: this doesn't update service configuration options!
 func (s *ServiceRegistry) UpdateService(newCfg client.ServiceConfig) error {
 	s.Lock()
 	defer s.Unlock()
@@ -571,5 +577,8 @@ func (s *ServiceRegistry) setServiceDefaults(svc *client.ServiceConfig) {
 	}
 	if svc.DialTimeout == 0 && s.cfg.DialTimeout != 0 {
 		svc.DialTimeout = s.cfg.DialTimeout
+	}
+	if s.cfg.HTTPSRedirect {
+		svc.HTTPSRedirect = true
 	}
 }

--- a/shuttle-cli/main.go
+++ b/shuttle-cli/main.go
@@ -41,6 +41,7 @@ func init() {
 	configFS.IntVar(&cfg.ClientTimeout, "client-timeout", 0, "innactivity timeout for client connections")
 	configFS.IntVar(&cfg.ServerTimeout, "server-timeout", 0, "innactivity timeout for server connections")
 	configFS.IntVar(&cfg.DialTimeout, "dial-timeout", 0, "timeout for dialing new connections connections")
+	configFS.BoolVar(&cfg.HTTPSRedirect, "https-redirect", false, "rediect all http requests to https")
 
 	serviceFS.StringVar(&serviceCfg.Addr, "address", "", "service listening address")
 	serviceFS.StringVar(&serviceCfg.Network, "network", "", "service network type")
@@ -51,6 +52,7 @@ func init() {
 	serviceFS.IntVar(&serviceCfg.ClientTimeout, "client-timeout", 0, "innactivity timeout for client connections")
 	serviceFS.IntVar(&serviceCfg.ServerTimeout, "server-timeout", 0, "innactivity timeout for server connections")
 	serviceFS.IntVar(&serviceCfg.DialTimeout, "dial-timeout", 0, "timeout for dialing new connections connections")
+	serviceFS.BoolVar(&serviceCfg.HTTPSRedirect, "https-redirect", false, "rediect all http requests to https")
 	serviceFS.Var(&vhosts, "vhost", "virtual host name. may be set multiple times")
 	serviceFS.Var(&errorPages, "error-page", "location for http error code formatted as 'http://example.com/|500,503'. may be set multiple times")
 


### PR DESCRIPTION
- allow http and https services to coexist
- add test to make sure our redirect behaviour works in the first place