### PR TITLE
Add a header indicating the backend used for http

### DIFF
--- a/reverseproxy.go
+++ b/reverseproxy.go
@@ -220,6 +220,7 @@ func (p *ReverseProxy) doRequest(pr *ProxyRequest) (*http.Response, error) {
 		resp, err = transport.RoundTrip(outreq)
 
 		if err == nil {
+			pr.ResponseWriter.Header().Set("X-Backend", addr)
 			return resp, nil
 		}
 

--- a/server_test.go
+++ b/server_test.go
@@ -268,5 +268,9 @@ func checkHTTP(url, host, expected string, status int, c Tester) {
 
 	c.Assert(resp.StatusCode, Equals, status)
 
+	if resp.StatusCode == http.StatusOK {
+		// check for our backend header, without possibly getting a cached error page
+		c.Assert(resp.Header.Get("X-Backend"), Equals, expected)
+	}
 	c.Assert(string(body), Equals, expected)
 }


### PR DESCRIPTION
- Help to easiy identify where a request was routed
- Insert an X-Backend header once we've succesfully made a RoundTrip
  with a backend. Since this happens inside the reverseproxy, there is
  unfortunately no way to ID it right now, except by ip:port.
- Fixes #18