### PR TITLE
allow Addr update if it was previously unset

### DIFF
--- a/service.go
+++ b/service.go
@@ -170,7 +170,7 @@ func (s *Service) UpdateConfig(cfg client.ServiceConfig) error {
 		return ErrInvalidServiceUpdate
 	}
 
-	if s.Addr != cfg.Addr {
+	if s.Addr != "" && s.Addr != cfg.Addr {
 		return ErrInvalidServiceUpdate
 	}
 


### PR DESCRIPTION
Commit a776984 introduced a prohibition against changing Addr due to
potential availability issues, but we should allow it if it wasn't
previously set.