### PR TITLE
add a Heroku-like maintenance mode

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -26,10 +26,22 @@ func getStats(w http.ResponseWriter, r *http.Request) {
 	w.Write(marshal(Registry.Stats()))
 }
 
-func getService(w http.ResponseWriter, r *http.Request) {
+func getServiceStats(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 
 	serviceStats, err := Registry.ServiceStats(vars["service"])
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	w.Write(marshal(serviceStats))
+}
+
+func getServiceConfig(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+
+	serviceStats, err := Registry.ServiceConfig(vars["service"])
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
@@ -120,6 +132,20 @@ func deleteService(w http.ResponseWriter, r *http.Request) {
 	w.Write(marshal(Registry.Config()))
 }
 
+func getBackendStats(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	serviceName := vars["service"]
+	backendName := vars["backend"]
+
+	backend, err := Registry.BackendStats(serviceName, backendName)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	w.Write(marshal(backend))
+}
+
 func getBackend(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	serviceName := vars["service"]
@@ -187,7 +213,9 @@ func addHandlers() {
 	r.HandleFunc("/_config", getConfig).Methods("GET")
 	r.HandleFunc("/_config", postConfig).Methods("PUT", "POST")
 	r.HandleFunc("/_stats", getStats).Methods("GET")
-	r.HandleFunc("/{service}", getService).Methods("GET")
+	r.HandleFunc("/{service}", getServiceStats).Methods("GET")
+	r.HandleFunc("/{service}/_config", getServiceConfig).Methods("GET")
+	r.HandleFunc("/{service}/_stats", getServiceStats).Methods("GET")
 	r.HandleFunc("/{service}", postService).Methods("PUT", "POST")
 	r.HandleFunc("/{service}", deleteService).Methods("DELETE")
 	r.HandleFunc("/{service}/{backend}", getBackend).Methods("GET")

--- a/client/config.go
+++ b/client/config.go
@@ -211,6 +211,10 @@ type ServiceConfig struct {
 
 	// Backends is a list of all servers handling connections for this service.
 	Backends []BackendConfig `json:"backends,omitempty"`
+
+	// Maintenance mode is a flag to return 503 status codes to clients
+	// without visiting backends.
+	MaintenanceMode bool `json:"maintenance_mode"`
 }
 
 // Return a copy  of ServiceConfig with any unset fields to their default
@@ -285,53 +289,56 @@ func (b *ServiceConfig) String() string {
 	return string(b.Marshal())
 }
 
-// Update any unset fields with those from the supplied config.
-// FIXME: HTTPSRedirect won't be turned off. Maybe change it to *bool?
-func (s *ServiceConfig) Merge(cfg ServiceConfig) {
+// Create a new config by merging the values from the current config
+// with those set in the new config
+func (s ServiceConfig) Merge(cfg ServiceConfig) ServiceConfig {
+	new := s
+
 	// let's try not to change the name
-	s.Name = cfg.Name
+	new.Name = cfg.Name
 
-	if s.Addr == "" {
-		s.Addr = cfg.Addr
+	if cfg.Addr != "" {
+		new.Addr = cfg.Addr
 	}
-	if s.Network == "" {
-		s.Network = cfg.Network
+	if cfg.Network != "" {
+		new.Network = cfg.Network
 	}
-	if s.Balance == "" {
-		s.Balance = cfg.Balance
+	if cfg.Balance != "" {
+		new.Balance = cfg.Balance
 	}
-	if s.CheckInterval == 0 {
-		s.CheckInterval = cfg.CheckInterval
+	if cfg.CheckInterval != 0 {
+		new.CheckInterval = cfg.CheckInterval
 	}
-	if s.Fall == 0 {
-		s.Fall = cfg.Fall
+	if cfg.Fall != 0 {
+		new.Fall = cfg.Fall
 	}
-	if s.Rise == 0 {
-		s.Rise = cfg.Rise
+	if cfg.Rise != 0 {
+		new.Rise = cfg.Rise
 	}
-	if s.ClientTimeout == 0 {
-		s.ClientTimeout = cfg.ClientTimeout
+	if cfg.ClientTimeout != 0 {
+		new.ClientTimeout = cfg.ClientTimeout
 	}
-	if s.ServerTimeout == 0 {
-		s.ServerTimeout = cfg.ServerTimeout
+	if cfg.ServerTimeout != 0 {
+		new.ServerTimeout = cfg.ServerTimeout
 	}
-	if s.DialTimeout == 0 {
-		s.DialTimeout = cfg.DialTimeout
-	}
-
-	if cfg.HTTPSRedirect {
-		s.HTTPSRedirect = cfg.HTTPSRedirect
+	if cfg.DialTimeout != 0 {
+		new.DialTimeout = cfg.DialTimeout
 	}
 
-	if s.VirtualHosts == nil {
-		s.VirtualHosts = cfg.VirtualHosts
+	if cfg.VirtualHosts != nil {
+		new.VirtualHosts = cfg.VirtualHosts
 	}
 
-	if s.ErrorPages == nil {
-		s.ErrorPages = cfg.ErrorPages
+	if cfg.ErrorPages != nil {
+		new.ErrorPages = cfg.ErrorPages
 	}
 
-	if s.Backends == nil {
-		s.Backends = cfg.Backends
+	if cfg.Backends != nil {
+		new.Backends = cfg.Backends
 	}
+
+	new.HTTPSRedirect = cfg.HTTPSRedirect
+	new.MaintenanceMode = cfg.MaintenanceMode
+
+	return new
 }

--- a/registry.go
+++ b/registry.go
@@ -293,7 +293,7 @@ func (s *ServiceRegistry) UpdateService(newCfg client.ServiceConfig) error {
 	}
 
 	currentCfg := service.Config()
-	newCfg.Merge(currentCfg)
+	newCfg = currentCfg.Merge(newCfg)
 
 	if err := service.UpdateConfig(newCfg); err != nil {
 		return err

--- a/shuttle_test.go
+++ b/shuttle_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -15,7 +16,7 @@ import (
 )
 
 func init() {
-	debug = false
+	debug = os.Getenv("SHUTTLE_DEBUG") == "1"
 
 	if debug {
 		log.DefaultLogger.Level = log.DEBUG


### PR DESCRIPTION
Shuttle will return 503 Service Unavailable errors to clients without
visiting backends if this is enabled.  If a 503 error page is cached
from backends, it will serve it.

Shuttle side of litl/galaxy#123