### PR TITLE
if X-Request-Id is set in request, append it to new ID

### DIFF
--- a/http.go
+++ b/http.go
@@ -46,7 +46,12 @@ func NewHostRouter(httpServer *http.Server) *HostRouter {
 }
 
 func (r *HostRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	reqId := genId()
+	reqId := req.Header.Get("X-Request-Id")
+	if reqId == "" {
+		reqId = genId()
+	} else {
+		reqId = genId() + "." + reqId
+	}
 	req.Header.Set("X-Request-Id", reqId)
 	w.Header().Add("X-Request-Id", reqId)
 

--- a/server_test.go
+++ b/server_test.go
@@ -229,6 +229,7 @@ func checkHTTP(url, host, expected string, status int, c Tester) {
 	}
 
 	req.Host = host
+	req.Header.Set("X-Request-Id", "foo")
 
 	// Load our test certs as our RootCAs, so we can verify that we connect
 	// with the correct Cert in an HTTPSRouter
@@ -265,6 +266,9 @@ func checkHTTP(url, host, expected string, status int, c Tester) {
 	if err != nil {
 		c.Fatal(err)
 	}
+
+	reqID := resp.Header.Get("X-Request-Id")
+	c.Assert(reqID[len(reqID)-4:], Equals, ".foo")
 
 	c.Assert(resp.StatusCode, Equals, status)
 


### PR DESCRIPTION
This lets services carry forward their request IDs, making it easier to
trace requests among multiple services.